### PR TITLE
International purchases must have a shipping adjustment

### DIFF
--- a/core/app/controllers/checkout_controller.rb
+++ b/core/app/controllers/checkout_controller.rb
@@ -87,6 +87,9 @@ class CheckoutController < Spree::BaseController
 
   def before_payment
     current_order.payments.destroy_all if request.put?
+    if @order.ship_address.country_id != 214 && @order.adjustments.shipping.empty?
+      redirect_to cart_path
+    end
   end
 
   def after_complete


### PR DESCRIPTION
caffeinatedlabs/craftcoffee#1484

This updates the checkout_controller so that international subscriptions must
have a shipping adjustment before their payment is process.  Previously,
it was possible to skip the delivery step in checkout and process an
international order without any shipping charges.  This will make you
go through the checkout process again if you somehow get to the payment
step with an int'l order and no shipping charges.
